### PR TITLE
Update EV locality lint

### DIFF
--- a/lib/certlint/cablint.rb
+++ b/lib/certlint/cablint.rb
@@ -255,8 +255,8 @@ module CertLint
         unless subjattrs.include? 'serialNumber'
           messages << 'E: EV certificates must include serialNumber in subject'
         end
-        unless subjattrs.include? 'L'
-          messages << 'E: EV certificates must include localityName in subject'
+        if !(subjattrs.include? 'L') && !(subjattrs.include? 'ST')
+            messages << 'E: EV certificates must include either localityName or stateOrProvinceName'
         end
         unless subjattrs.include? 'C'
           messages << 'E: EV certificates must include countryName in subject'


### PR DESCRIPTION
Since EV ver 1.6.4 and ballot 191, localityName is optional if stateOrProvinceName is present.