### PR TITLE
Downgrade deprecated attribute Warning to Information.

### DIFF
--- a/lib/certlint/namelint.rb
+++ b/lib/certlint/namelint.rb
@@ -142,7 +142,7 @@ module CertLint
           end
 
           if DEPRECATED_ATTRIBUTES.include? type
-            attr_messages << "W: Name has deprecated attribute #{attrname}"
+            attr_messages << "I: Name has deprecated attribute #{attrname}"
           end
 
           attr_messages += CertLint.check_pdu(pdu, value.to_der)


### PR DESCRIPTION
RFC5280 explains that `new certificates with electronic mail addresses MUST use the rfc822Name in the subject alternative name extension`, and that the PKCS#9 emailAddress Subject attribute is an artifact of `legacy implementations`.  However, it also says that `Simultaneous inclusion of the emailAddress attribute in the subject distinguished name to support legacy implementations is deprecated but permitted.`

Certlint currently shows a Warning when the emailAddress Subject attribute is encountered.  However, https://github.com/certlint/certlint#output says that Warnings are for `issues where a standard recommends differently but the standard uses terms such as "SHOULD" or "MAY"`, and ISTM that the `deprecated but permitted` sentence doesn't meet that definition due to the lack of any RFC2119 keywords.

It's not uncommon for CAs to block issuance due to pre-issuance linter Warnings, so it seems appropriate to downgrade the level of this particular lint to Information, given that `Simultaneous inclusion of the emailAddress address is...permitted`.