### PR TITLE
Move duplicate Subject attribute check from Certlint to CABlint

### DIFF
--- a/lib/certlint/cablint.rb
+++ b/lib/certlint/cablint.rb
@@ -567,6 +567,19 @@ module CertLint
             end
           end
         end
+
+        attr_types = subjectarr.map { |attr| attr[0] }
+        dup = attr_types.select { |el| attr_types.count(el) > 1 }.uniq
+        # streetAddress, OU, and DC can reasonably appear multiple times
+        dup.delete('street')
+        dup.delete('OU')
+        dup.delete('DC')
+        # There are people with multiple given names and surnames
+        dup.delete('GN')
+        dup.delete('SN')
+        dup.each do |type|
+          messages << "W: Name has multiple #{type} attributes"
+        end
       end
 
       unless cert_type_identified

--- a/lib/certlint/namelint.rb
+++ b/lib/certlint/namelint.rb
@@ -261,19 +261,6 @@ module CertLint
         end
       end
 
-      dup = attr_types.select { |el| attr_types.count(el) > 1 }.uniq
-      # streetAddress, OU, and DC can reasonably appear multiple times
-      dup.delete('2.5.4.9')
-      dup.delete('2.5.4.11')
-      dup.delete('0.9.2342.19200300.100.1.25')
-      # There are people with multiple given names and surnames
-      dup.delete('2.5.4.42')
-      dup.delete('2.5.4.4')
-      dup.each do |type|
-        attrname = attr_name(type)
-        messages << "W: Name has multiple #{attrname} attributes"
-      end
-
       # Empty names are valid but cause an exception when converting to a string
       if name.to_a.length > 0
         # Can OpenSSL handle the name?


### PR DESCRIPTION
Certlint currently warns when there are multiple Subject attributes of the same type, except for streetAddress, organizationalUnit, domainComponent, givenName, and surname.  Although this seems sensible and is broadly in line with the BRs and EVGs, it's not an RFC5280 rule and so it's a bit too opinionated for vanilla Certlint.