### PR TITLE
Downgrade example.com|net|org finding from error to notice

### DIFF
--- a/lib/certlint/iananames.rb
+++ b/lib/certlint/iananames.rb
@@ -29,6 +29,7 @@ module CertLint
     @special_domains = nil
     def self.load_domains
       @iana_tlds = {}
+      @example_domains = ["example.com", "example.net", "example.org"]
       @special_domains = []
       spec_domains = {}
 
@@ -111,7 +112,11 @@ module CertLint
       end
 
       if ('.' + fqdn).end_with?(*@special_domains)
-        messages << 'E: FQDN under reserved or special domain'
+        if ('.' + fqdn).end_with?(*@example_domains)
+          messages << 'N: FQDN under example domain'
+        else
+          messages << 'E: FQDN under reserved or special domain'
+        end
       end
 
       if fqdn.include? 'xn--'


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc6761.html#section-6.5 explains that "IANA currently maintains a web server providing a web page explaining the purpose of example domains"; these web pages are served over HTTPS using certificates from publicly-trusted CAs.  Given that CAs tend to block issuance on linter warnings and errors, this PR is necessary to enable this use case.